### PR TITLE
Fixed the build by setting enable bitcode to no

### DIFF
--- a/SpeedTest.xcodeproj/project.pbxproj
+++ b/SpeedTest.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 			baseConfigurationReference = 31EEB178150FD20325FBCFF8 /* Pods-SpeedTest.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = SpeedTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.socialradar.$(PRODUCT_NAME:rfc1034identifier)";
@@ -430,6 +431,7 @@
 			baseConfigurationReference = 1BC416960004B62948EA7AB8 /* Pods-SpeedTest.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = SpeedTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.socialradar.$(PRODUCT_NAME:rfc1034identifier)";


### PR DESCRIPTION
I receive the following compilation error when bitcode is set to yes:

> When /path/to/SpeedTest-Swift/Pods/LocationKit/LocationKit.framework/LocationKit(LKSEGSegmentioIntegration.o)' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target.
